### PR TITLE
Fixed segfault in affinfo's verification

### DIFF
--- a/tools/affinfo.cpp
+++ b/tools/affinfo.cpp
@@ -230,6 +230,7 @@ void validate(const char *infile)
 	printf("No pages to validate.\n");
     error_code |= ERROR_NO_PAGES;
 	af_close(af);
+        return;
     }
 
     sort(pages.begin(),pages.end());


### PR DESCRIPTION
When there weren't any verifiable pages in an AFF file it was detected and pre-exit cleanup was done, but the function simply didn't return.  A few lines later an iterator dereference that should be guaranteed safe was causing the segfault.

Also, could you add me as a committer for AFFLIB?
