### PR TITLE
Fix broken build on OS X using MacPorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ m4/lt~obsolete.m4
 missing
 stamp-h*
 depcomp
+test-driver
 
 # Executables
 .deps

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AM_MAINTAINER_MODE
 AC_CONFIG_FILES([Makefile lib/Makefile tools/Makefile lzma443/Makefile 
 			  tests/Makefile doc/Makefile pyaff/Makefile man/Makefile lib/version.h])
 AC_CONFIG_FILES([afflib.spec])
-AM_CONFIG_HEADER([affconfig.h])
+AC_CONFIG_HEADERS([affconfig.h])
 
 # Where we get installed
 AC_PREFIX_PROGRAM


### PR DESCRIPTION
MacPort's autoconf dies on encountering a now-obsolete macro.  This pull request fixes the macro invocation the same way The Sleuth Kit required a fix for building in OS X.

Also in OS X, the autotools generate another file .gitignore can catch.
