### PR TITLE
Update configure to properly detect libressl without breaking openssl compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,16 +220,17 @@ AM_CONDITIONAL(HAVE_PYTHON, test "$enable_python" = yes)
 ## Note: -lssl is needed on Linux
 ##       -lcrypto is needed on MacOS
 ##       -lmd is needed on some older systems
+##       -lssl and -lcrypto are needed if using libressl
 ## Always check for headers, then libs, then functions
 ###
 
 AC_CHECK_HEADERS([openssl/aes.h openssl/bio.h openssl/evp.h openssl/hmac.h openssl/md5.h openssl/rand.h openssl/rsa.h openssl/sha.h openssl/pem.h openssl/x509.h])
 
+AC_CHECK_LIB([crypto],[EVP_get_digestbyname])
 
 AC_CHECK_LIB([ssl],[SSL_library_init],,
 	AC_MSG_ERROR([OpenSSL developer library 'libssl-dev' or 'openssl-devel' not installed; cannot continue.]))
 
-AC_CHECK_LIB([crypto],[EVP_get_digestbyname])
 AC_CHECK_LIB([md],[MD5])		# if libmd is available, get it
 
 AC_CHECK_FUNCS([MD5 SHA1 AES_encrypt RAND_pseudo_bytes des_read_pw_string EVP_read_pw_string EVP_MD_size])


### PR DESCRIPTION
libressl is the new openbsd fork of openssl.  http://www.libressl.org  I was performing libressl compatibility testing on my gentoo linux system and discovered that AFFLIB generated a fatal error during configure: it was not able to detect a ussable openssl installation.

Openssl's libssl linked sucessfully with -lssl, but libressl's libssl requires both -lssl and -lcrypto.  Both can link against libcrypto with just -lcrypto.

AFFLIB's configure script checks for libssl before libcrypto, so the libssl check uses just -lssl and fails with libressl.  Simply changing the order of the tests resolves the issue.  By checking libcrypto first, -lcrypto is added to configure's $LIBS, so the libssl test will use both -lssl and -lcrypto.

This pull request implements that change.  I have tested with both openssl 1.0.1h and libressl 2.0.5 on my gentoo linux system.  In both cases the updated configure script detects the openssl installation properly and compiles without errors.
